### PR TITLE
Update mkdocs-requirements.txt

### DIFF
--- a/workspaces/base-workspace/mkdocs-requirements.txt
+++ b/workspaces/base-workspace/mkdocs-requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.2.1
+mkdocs==1.2.3
 # https://squidfunk.github.io/mkdocs-material/getting-started/#installation
 mkdocs-material==7.1.8
 # https://github.com/fralau/mkdocs_macros_plugin


### PR DESCRIPTION
Updating mkdocs to 1.2.3 to fix issue on M1 Macs that prevents the site to be served.

Fixes #4 